### PR TITLE
Pr 1.0.7

### DIFF
--- a/playbooks/10 - SP - FortiManager ZTP Flow - FortiManager(FMG)-RecordHandlers/> render jinja template.json
+++ b/playbooks/10 - SP - FortiManager ZTP Flow - FortiManager(FMG)-RecordHandlers/> render jinja template.json
@@ -60,7 +60,7 @@
             "name": "extract_results",
             "description": null,
             "arguments": {
-                "output": "{{vars.steps.Convert_Jinja_to_String.data.result}}"
+                "output": "{%- set output = vars.steps.Convert_Jinja_to_String.data.result -%}\n\n{%- if output is not defined or output is none -%}\n  {{ \"Error: No output found\" }}\n{%- elif (output | type_debug == \"dict\") or (output | type_debug == \"list\") -%}\n  {{ output }}\n{%- elif output | type_debug == \"str\" -%}\n  {%- if output.strip().startswith('\"{\"') or output.strip().startswith('\"{') -%}\n    {%- set cleaned_str = output.strip('\"').replace('\\\\n', ' ').replace('\\\\\"', '\"') -%}\n    {%- if cleaned_str.strip().startswith('{') and cleaned_str.strip().endswith('}') -%}\n      {{ cleaned_str | toDict }}\n    {%- else -%}\n      {{ output }}\n    {%- endif -%}\n  {%- else -%}\n    {{ output }}\n  {%- endif -%}\n{%- else -%}\n  {{ \"Error: Unexpected data type: \" + (output | type_debug) }}\n{%- endif -%}"
             },
             "status": null,
             "top": "380",
@@ -120,7 +120,25 @@
             "uuid": "0174bbbc-91bc-42cc-a3e9-6e0daef03998"
         }
     ],
-    "groups": [],
+    "groups": [
+        {
+            "@type": "WorkflowGroup",
+            "name": "Change Log",
+            "description": "3\/31\/25 Update extract results to better handle parsing scenarios where the conversion results may be a string and not a dictionary - DS",
+            "type": "note",
+            "isCollapsed": false,
+            "hasTriggerStep": false,
+            "hideInLogs": true,
+            "metadata": [],
+            "reusable": false,
+            "top": "240",
+            "left": "620",
+            "height": "146",
+            "width": "498",
+            "uuid": "53c5ec66-ba7b-4bb5-87c2-60b765059eb1",
+            "recordTags": []
+        }
+    ],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "uuid": "8aff2bb3-7d1c-45f1-aae9-ea816aea874d",
     "owners": [],

--- a/playbooks/10 - SP - FortiManager ZTP Flow - FortiManager(FMG)-RecordHandlers/> ztp profile assignment search.json
+++ b/playbooks/10 - SP - FortiManager ZTP Flow - FortiManager(FMG)-RecordHandlers/> ztp profile assignment search.json
@@ -37,7 +37,7 @@
             "name": "extract_jinja_results",
             "description": null,
             "arguments": {
-                "search_results": "{%- set i = namespace(x=0) -%}\n{%- set table = [] -%}\n{%- for dev in vars.device_record_data -%}\n  {%- set idx = {} -%}\n  {%- if vars.steps.render_jinja[i.x].output != \"\" -%}\n    {%- set ret = true -%}    \n  {%- endif -%}\n  {%- set _do = idx.update( {\n      \"ztp_profile_id\":vars.ztp_profile_id,\n      \"id\":dev.id,\n      \"matched\": ret|default(false),\n      \"jinja_vars\":vars.steps.get_jinja_vars[i.x].output,\n      \"jinja_search\":vars.zprof_search\n    } ) -%}\n  {%- set _do = table.append(idx)  -%}\n  {%- set i.x = i.x+1 -%}\n{%- endfor -%}\n{{table}}"
+                "search_results": "{%- set i = namespace(x=0) -%}\n{%- set table = [] -%}\n{%- for dev in vars.device_record_data -%}\n  {%- set idx = {} -%}\n  {%- if vars.steps.render_jinja[i.x].output not in [\"\", False, \"false\", \"False\"] -%}\n    {%- set ret = true -%}    \n  {%- endif -%}\n  {%- set _do = idx.update( {\n      \"ztp_profile_id\":vars.ztp_profile_id,\n      \"id\":dev.id,\n      \"matched\": ret|default(false),\n      \"jinja_vars\":vars.steps.get_jinja_vars[i.x].output,\n      \"jinja_search\":vars.zprof_search\n    } ) -%}\n  {%- set _do = table.append(idx)  -%}\n  {%- set i.x = i.x+1 -%}\n{%- endfor -%}\n{{table}}"
             },
             "status": null,
             "top": "680",
@@ -470,6 +470,23 @@
         }
     ],
     "groups": [
+        {
+            "@type": "WorkflowGroup",
+            "name": "Change Log",
+            "description": "3\/31\/25 - `extract_jinja_results` step is too permisive. It only checks if output is not each to \"\". Changed to   {%- if vars.steps.render_jinja[i.x].output not in [\"\", False, \"false\", \"False\"] -%} - DS",
+            "type": "note",
+            "isCollapsed": false,
+            "hasTriggerStep": false,
+            "hideInLogs": true,
+            "metadata": [],
+            "reusable": false,
+            "top": "80",
+            "left": "1560",
+            "height": "161",
+            "width": "464",
+            "uuid": "f0970d19-99c9-4fc7-b7b1-d562657fc817",
+            "recordTags": []
+        },
         {
             "@type": "WorkflowGroup",
             "name": "Jinja",

--- a/playbooks/10 - SP - FortiManager ZTP Flow - FortiManager(FMG)-Triggers/On ZTP Phase (Action Step) in Device Record.json
+++ b/playbooks/10 - SP - FortiManager ZTP Flow - FortiManager(FMG)-Triggers/On ZTP Phase (Action Step) in Device Record.json
@@ -444,9 +444,7 @@
                 },
                 "apply_async": false,
                 "ignore_errors": true,
-                "step_variables": {
-                    "phase_results": "{{vars.steps.run_linked_scripts}}"
-                },
+                "step_variables": [],
                 "pass_parent_env": false,
                 "pass_input_record": false,
                 "workflowReference": "\/api\/3\/workflows\/40821204-db12-4122-8ecd-ba6e944a058c"
@@ -457,6 +455,20 @@
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "eacd0ca0-f11f-458f-8465-7eda07222054"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "run_linked_scripts",
+            "description": null,
+            "arguments": {
+                "phase_results": "{{vars.steps.run_linked_scripts}}"
+            },
+            "status": null,
+            "top": "620",
+            "left": "1460",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "da4de20e-a2f2-42ed-b1bc-989a874328b4"
         },
         {
             "@type": "WorkflowStep",
@@ -1026,6 +1038,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "run linked scripts -> run_linked_scripts",
+            "targetStep": "\/api\/3\/workflow_steps\/da4de20e-a2f2-42ed-b1bc-989a874328b4",
+            "sourceStep": "\/api\/3\/workflow_steps\/eacd0ca0-f11f-458f-8465-7eda07222054",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "73c94059-61c2-4655-a838-f13893e51fa7"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "run_linked_scripts_vars -> run linked scripts",
             "targetStep": "\/api\/3\/workflow_steps\/eacd0ca0-f11f-458f-8465-7eda07222054",
             "sourceStep": "\/api\/3\/workflow_steps\/0ecd9d9f-3be8-4fa7-9738-e181666aedbd",
@@ -1036,13 +1058,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "run linked scripts -> ztp_phase_complete_vars",
+            "name": "run_linked_scripts -> ztp_phase_complete_vars",
             "targetStep": "\/api\/3\/workflow_steps\/96960759-a39a-42c4-9b69-62b9597f1522",
-            "sourceStep": "\/api\/3\/workflow_steps\/eacd0ca0-f11f-458f-8465-7eda07222054",
+            "sourceStep": "\/api\/3\/workflow_steps\/da4de20e-a2f2-42ed-b1bc-989a874328b4",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "0aaa4993-ec6c-4d48-87f9-25a97ff885c2"
+            "uuid": "20e6c9e0-7861-4c76-94f3-a95c1dcd3697"
         },
         {
             "@type": "WorkflowRoute",
@@ -1205,7 +1227,25 @@
             "uuid": "89bccc58-08f4-4f37-97e8-01068ad8b4d7"
         }
     ],
-    "groups": [],
+    "groups": [
+        {
+            "@type": "WorkflowGroup",
+            "name": "Change Log",
+            "description": "3\/31\/25 Added a set variable step after run_linked_scripts as some odd behavior was seen where the inline set variable step was not 100% working -DS",
+            "type": "note",
+            "isCollapsed": false,
+            "hasTriggerStep": false,
+            "hideInLogs": true,
+            "metadata": [],
+            "reusable": false,
+            "top": "180",
+            "left": "2780",
+            "height": "177",
+            "width": "417",
+            "uuid": "6d8572f3-a1cf-4739-8df0-d6ad2afed281",
+            "recordTags": []
+        }
+    ],
     "priority": "\/api\/3\/picklists\/df314249-88c8-4778-ab55-8aeafbe932cb",
     "uuid": "8fdcdcb0-0511-401a-9485-3b61ccfc8cc4",
     "owners": [],


### PR DESCRIPTION
This pull request includes several changes to improve the handling of Jinja template parsing and workflow steps in the FortiManager ZTP Flow playbooks. The most important changes include updates to the Jinja template parsing logic, the addition of workflow groups for change logs

Improvements to Jinja template parsing:

* Updated the `extract_results` step to better handle scenarios where the conversion results may be a string instead of a dictionary.
* Modified the `extract_jinja_results` step to check if the output is not in a set of false values

Additions of change log groups:

* Added a "Change Log" workflow group to document updates to the `extract_results` step.
* Added a "Change Log" workflow group to document changes to the `extract_jinja_results` step.
* Added a "Change Log" workflow group to document the addition of a set variable step after `run_linked_scripts`.